### PR TITLE
fix: add privacy-safe logging to data pipeline and remove personal da…

### DIFF
--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -33,7 +33,7 @@ export function SettingsView() {
     const path = await pickJournalDirectory()
     if (!path) return
 
-    console.log('[new-journal] Selected path:', path)
+    console.log('[new-journal] Directory selected')
 
     // Clear IndexedDB entries and profile
     await del('nopy-entries')
@@ -45,7 +45,7 @@ export function SettingsView() {
     setJournalPath(path)
     await grantFsScope(path)
 
-    console.log('[new-journal] Path set, scope granted. Current settings path:', useSettingsStore.getState().journalPath)
+    console.log('[new-journal] Path set, scope granted')
 
     // Sync from the new location
     await useJournalStore.getState().loadEntries()

--- a/src/services/anthropic.ts
+++ b/src/services/anthropic.ts
@@ -4,7 +4,11 @@ let clientInstance: Anthropic | null = null
 let currentApiKey = ''
 
 export function getClient(apiKey: string): Anthropic {
-  if (clientInstance && currentApiKey === apiKey) return clientInstance
+  if (clientInstance && currentApiKey === apiKey) {
+    console.log('[anthropic] getClient: reusing existing client')
+    return clientInstance
+  }
+  console.log('[anthropic] getClient: creating new client instance')
   clientInstance = new Anthropic({ apiKey, dangerouslyAllowBrowser: true })
   currentApiKey = apiKey
   return clientInstance
@@ -20,6 +24,7 @@ export async function streamChatResponse(
   onComplete: (fullText: string) => void,
   onError: (error: Error) => void,
 ): Promise<void> {
+  console.log('[anthropic] streamChatResponse: model', model, '| messages', messages.length, '| maxTokens', maxTokens)
   try {
     const client = getClient(apiKey)
     const stream = client.messages.stream({
@@ -37,24 +42,30 @@ export async function streamChatResponse(
     })
 
     stream.on('finalMessage', () => {
+      console.log('[anthropic] streamChatResponse: complete —', fullText.length, 'chars received')
       onComplete(fullText)
     })
 
     stream.on('error', (error) => {
+      console.error('[anthropic] streamChatResponse: stream error —', error instanceof Error ? error.message : String(error))
       onError(error instanceof Error ? error : new Error(String(error)))
     })
   } catch (error) {
+    console.error('[anthropic] streamChatResponse: caught error —', error instanceof Error ? error.message : String(error))
     onError(error instanceof Error ? error : new Error(String(error)))
   }
 }
 
 export async function fetchModels(apiKey: string): Promise<{ id: string; displayName: string }[]> {
+  console.log('[anthropic] fetchModels: requesting model list')
   const client = getClient(apiKey)
   const response = await client.models.list({ limit: 100 })
-  return response.data
+  const filtered = response.data
     .filter((m) => m.id.startsWith('claude-'))
     .map((m) => ({ id: m.id, displayName: m.display_name ?? m.id }))
     .sort((a, b) => a.displayName.localeCompare(b.displayName))
+  console.log('[anthropic] fetchModels: total', response.data.length, '| after claude filter', filtered.length)
+  return filtered
 }
 
 export async function sendMessage(
@@ -65,6 +76,7 @@ export async function sendMessage(
   maxTokens: number = 500,
   signal?: AbortSignal,
 ): Promise<string> {
+  console.log('[anthropic] sendMessage: model', model, '| messages', messages.length, '| maxTokens', maxTokens)
   const client = getClient(apiKey)
   const response = await client.messages.create(
     {
@@ -76,5 +88,7 @@ export async function sendMessage(
     { signal },
   )
   const block = response.content[0]
-  return block?.type === 'text' ? block.text : ''
+  const text = block?.type === 'text' ? block.text : ''
+  console.log('[anthropic] sendMessage: response', text.length, 'chars | stop_reason', response.stop_reason)
+  return text
 }

--- a/src/services/contextAssembler.ts
+++ b/src/services/contextAssembler.ts
@@ -42,7 +42,7 @@ export function assembleContext(
   if (profile && profile.themes.length > 0) {
     const themesStr = profile.themes.map((t) => t.theme).join(', ')
     system += `\n\nRecurring themes: ${themesStr}`
-    console.log('[contextAssembler] ✓ Injected themes:', themesStr)
+    console.log('[contextAssembler] ✓ Injected themes:', profile.themes.length, 'themes')
   }
 
   // Inject entry index table (background reference — capped to most recent entries)
@@ -70,10 +70,7 @@ export function assembleContext(
   if (entryContext) {
     const dateStr = entryContext.date ? new Date(entryContext.date).toLocaleDateString() : 'undated'
     system += `\n\n## Current Session Focus\nThis journal entry is the focus of the entire session. Reference its specific content throughout the conversation when relevant. Do not ask the user to share it — you have the full text below.\n\n**${entryContext.title}** (${dateStr})\n\n${entryContext.content}`
-    console.log('[contextAssembler] ✓ Injected entry context:')
-    console.log('[contextAssembler]   Title:', entryContext.title)
-    console.log('[contextAssembler]   Date:', dateStr)
-    console.log('[contextAssembler]   Content length:', entryContext.content.length, 'chars')
+    console.log('[contextAssembler] ✓ Injected entry context: date:', dateStr, '| content:', entryContext.content.length, 'chars')
   }
 
   const systemTokens = estimateTokens(system)
@@ -91,8 +88,7 @@ export function assembleContext(
       role: 'assistant',
       content: "I remember our conversation. Let's continue from where we left off.",
     })
-    console.log('[contextAssembler] ✓ Injected session summary (session has', session.messages.length, 'messages)')
-    console.log('[contextAssembler]   Summary:', session.summary.slice(0, 100) + (session.summary.length > 100 ? '...' : ''))
+    console.log('[contextAssembler] ✓ Injected session summary (session has', session.messages.length, 'messages, summary:', session.summary.length, 'chars)')
   }
 
   // Take recent messages that fit within budget
@@ -130,18 +126,6 @@ export function assembleContext(
     console.log('[contextAssembler]   Skipped streaming messages:', skippedStreaming)
   }
   console.log('[contextAssembler]   Message tokens used:', tokenCount)
-
-  // Log message preview
-  if (recentMessages.length > 0) {
-    console.log('[contextAssembler] Message preview (first 3):')
-    recentMessages.slice(0, 3).forEach((msg, i) => {
-      const preview = msg.content.slice(0, 80).replace(/\n/g, ' ')
-      console.log(`[contextAssembler]   [${i}] ${msg.role}: "${preview}${msg.content.length > 80 ? '...' : ''}"`)
-    })
-    if (recentMessages.length > 3) {
-      console.log(`[contextAssembler]   ... and ${recentMessages.length - 3} more messages`)
-    }
-  }
 
   const totalTokens = systemTokens + tokenCount
   console.log('[contextAssembler] ========== CONTEXT ASSEMBLED ==========')

--- a/src/services/entryProcessor.ts
+++ b/src/services/entryProcessor.ts
@@ -13,6 +13,8 @@ interface EntryMetadata {
 }
 
 export async function processEntry(entry: JournalEntry, apiKey: string, signal?: AbortSignal): Promise<EntryMetadata> {
+  const inputChars = (entry.title.length + entry.content.length)
+  console.log('[entryProcessor] processEntry: input', inputChars, 'chars')
   const response = await sendMessage(
     apiKey,
     HAIKU_MODEL,
@@ -31,13 +33,15 @@ No markdown, no explanation, just the JSON object.`,
     signal,
   )
 
+  console.log('[entryProcessor] processEntry: response', response.length, 'chars')
   try {
     // Strip any markdown code fences if present
     const cleaned = response.replace(/```json?\n?/g, '').replace(/```/g, '').trim()
     const parsed = EntryMetadataCoercedSchema.parse(JSON.parse(cleaned))
+    console.log('[entryProcessor] processEntry: parsed ok — mood:', parsed.mood.value, '/', parsed.mood.label, '| tags:', parsed.tags.length, '| summary:', parsed.summary.length, 'chars')
     return parsed
   } catch (e) {
-    console.error('[processor] Failed to parse Haiku response:', response, e)
+    console.error('[entryProcessor] processEntry: parse failed — response length:', response.length, 'chars |', e)
     throw new Error(`Failed to parse entry metadata: ${e}`)
   }
 }
@@ -50,6 +54,7 @@ export async function processAllEntries(
   signal?: AbortSignal,
 ): Promise<Map<string, EntryMetadata>> {
   const toProcess = force ? entries : entries.filter((e) => !e.indexed)
+  console.log('[entryProcessor] processAllEntries: total', entries.length, '| to process', toProcess.length, '| skipped (already indexed)', entries.length - toProcess.length, '| force:', force)
   const results = new Map<string, EntryMetadata>()
 
   for (let i = 0; i < toProcess.length; i++) {
@@ -60,11 +65,11 @@ export async function processAllEntries(
       const metadata = await processEntry(entry, apiKey, signal)
       results.set(entry.id, metadata)
     } catch (e) {
-      console.error(`[processor] Failed to process entry "${entry.title}":`, e)
-      // Continue with other entries
+      console.error('[entryProcessor] processAllEntries: entry', i + 1, 'of', toProcess.length, 'failed —', e)
     }
   }
 
+  console.log('[entryProcessor] processAllEntries: complete —', results.size, 'of', toProcess.length, 'succeeded')
   return results
 }
 
@@ -75,10 +80,15 @@ export async function generateProfileFromEntries(
 ): Promise<Omit<PsychologicalProfile, 'averageMood' | 'journalingStreak' | 'avgEntryLength' | 'reflectionDepth' | 'emotionalDistribution' | 'updatedAt' | 'entriesAnalysed'>> {
   // Build context from all indexed entries
   const indexed = entries.filter((e) => e.indexed && e.summary)
+  console.log('[entryProcessor] generateProfileFromEntries: indexed entries', indexed.length)
   const entrySummaries = indexed
     .map((e) => `[${e.createdAt.slice(0, 10)}] ${e.title}: ${e.summary} (mood: ${e.mood?.value ?? 'n/a'}/10, tags: ${e.tags.join(', ')})`)
     .join('\n')
 
+  const entrySummariesChars = indexed
+    .map((e) => `[${e.createdAt.slice(0, 10)}] ${e.title}: ${e.summary} (mood: ${e.mood?.value ?? 'n/a'}/10, tags: ${e.tags.join(', ')})`)
+    .join('\n').length
+  console.log('[entryProcessor] generateProfileFromEntries: sending', entrySummariesChars, 'chars to Haiku')
   const response = await sendMessage(
     apiKey,
     HAIKU_MODEL,
@@ -101,11 +111,14 @@ No markdown, just JSON.`,
     signal,
   )
 
+  console.log('[entryProcessor] generateProfileFromEntries: response', response.length, 'chars')
   try {
     const cleaned = response.replace(/```json?\n?/g, '').replace(/```/g, '').trim()
-    return ProfileResponseSchema.parse(JSON.parse(cleaned))
+    const parsed = ProfileResponseSchema.parse(JSON.parse(cleaned))
+    console.log('[entryProcessor] generateProfileFromEntries: parsed ok — themes:', parsed.themes.length, '| cognitivePatterns:', parsed.cognitivePatterns.length, '| strengths:', parsed.strengths.length)
+    return parsed
   } catch (e) {
-    console.error('[processor] Failed to parse profile response:', response, e)
+    console.error('[entryProcessor] generateProfileFromEntries: parse failed — response length:', response.length, 'chars |', e)
     throw new Error(`Failed to generate profile: ${e}`)
   }
 }
@@ -118,6 +131,7 @@ export async function generateFullProfile(
   signal?: AbortSignal,
 ): Promise<string> {
   const indexed = entries.filter((e) => e.indexed)
+  console.log('[entryProcessor] generateFullProfile: indexed entries', indexed.length)
 
   // Build full entry content for Opus (send actual content, not just summaries)
   const entryContent = indexed
@@ -130,6 +144,7 @@ export async function generateFullProfile(
     })
     .join('\n\n')
 
+  console.log('[entryProcessor] generateFullProfile: sending', entryContent.length, 'chars to Opus')
   const response = await sendMessage(
     apiKey,
     OPUS_MODEL,
@@ -188,6 +203,7 @@ Guidelines:
     signal,
   )
 
+  console.log('[entryProcessor] generateFullProfile: response', response.length, 'chars')
   return response
 }
 
@@ -198,8 +214,10 @@ export function computeLocalStats(entries: JournalEntry[]): {
   avgEntryLength: number
   reflectionDepth: 'Low' | 'Medium' | 'High'
 } {
+  console.log('[entryProcessor] computeLocalStats: entries', entries.length)
   const indexed = entries.filter((e) => e.indexed)
   if (indexed.length === 0) {
+    console.log('[entryProcessor] computeLocalStats: no indexed entries — returning zeros')
     return {
       averageMood: 0,
       journalingStreak: 0,
@@ -236,6 +254,7 @@ export function computeLocalStats(entries: JournalEntry[]): {
   const reflectionDepth: 'Low' | 'Medium' | 'High' =
     avgEntryLength >= 300 ? 'High' : avgEntryLength >= 150 ? 'Medium' : 'Low'
 
+  console.log('[entryProcessor] computeLocalStats: averageMood', averageMood, '| streak', journalingStreak, '| avgEntryLength', avgEntryLength, '| reflectionDepth', reflectionDepth)
   return { averageMood, journalingStreak, avgEntryLength, reflectionDepth }
 }
 

--- a/src/services/fs.ts
+++ b/src/services/fs.ts
@@ -39,9 +39,13 @@ function entryToMarkdown(entry: JournalEntry): string {
 
 function parseMarkdown(text: string): { frontmatter: Record<string, unknown>; content: string } {
   const match = text.match(/^---\n([\s\S]*?)\n---\n\n?([\s\S]*)$/)
-  if (!match) return { frontmatter: {}, content: text }
+  if (!match) {
+    console.log('[fs] parseMarkdown: no frontmatter found')
+    return { frontmatter: {}, content: text }
+  }
 
   const frontmatter: Record<string, unknown> = {}
+  let parseFailures = 0
   for (const line of match[1].split('\n')) {
     const idx = line.indexOf(': ')
     if (idx === -1) continue
@@ -50,9 +54,11 @@ function parseMarkdown(text: string): { frontmatter: Record<string, unknown>; co
     try {
       frontmatter[key] = JSON.parse(value)
     } catch {
+      parseFailures++
       frontmatter[key] = value
     }
   }
+  console.log('[fs] parseMarkdown: frontmatter keys', Object.keys(frontmatter).length, '| JSON parse failures', parseFailures)
   return { frontmatter, content: match[2] }
 }
 
@@ -196,6 +202,7 @@ export async function loadEntriesFromDisk(journalPath: string): Promise<JournalE
         // If no date at all (e.g. "my-note.md"), use cleaned filename
         const titleFromFilename = titleAfterDate || nameWithoutExt
 
+        console.log('[fs] loadEntriesFromDisk: file', file.name, '| type', hasFrontmatter ? 'nopy' : 'plain import', '| frontmatter valid', frontmatterResult.success)
         entries.push({
           id: fm?.id || crypto.randomUUID(),
           title: hasFrontmatter

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -42,10 +42,12 @@ export const useChatStore = create<ChatState>()((setState, getState) => ({
 
   loadSessionList: async () => {
     const meta = await get<ChatSessionMeta[]>('chat:meta')
+    console.log('[chatStore] loadSessionList: loaded', (meta ?? []).length, 'sessions')
     setState({ sessions: meta ?? [], loaded: true })
   },
 
   createSession: async (entryContext?: ChatEntryContext) => {
+    console.log('[chatStore] createSession: entryContext present', entryContext != null)
     const now = new Date().toISOString()
     const session: ChatSession = {
       id: crypto.randomUUID(),
@@ -58,6 +60,7 @@ export const useChatStore = create<ChatState>()((setState, getState) => ({
       entryContext: entryContext ?? null,
     }
     await set(`chat:session:${session.id}`, session)
+    console.log('[chatStore] createSession: created session', session.id)
     const meta = toMeta(session)
     const sessions = [meta, ...getState().sessions]
     setState({ sessions, activeSession: session, activeSessionId: session.id })
@@ -67,6 +70,7 @@ export const useChatStore = create<ChatState>()((setState, getState) => ({
 
   loadSession: async (id) => {
     const session = await get<ChatSession>(`chat:session:${id}`)
+    console.log('[chatStore] loadSession: id', id, '| found', session != null, '| messages', session?.messages.length ?? 0)
     if (session) {
       setState({ activeSession: session, activeSessionId: id })
     }
@@ -75,6 +79,7 @@ export const useChatStore = create<ChatState>()((setState, getState) => ({
   addMessage: async (message) => {
     const state = getState()
     if (!state.activeSession) return
+    console.log('[chatStore] addMessage: role', message.role, '| content', message.content.length, 'chars | session', state.activeSession.id)
     const updatedSession: ChatSession = {
       ...state.activeSession,
       messages: [...state.activeSession.messages, message],
@@ -104,6 +109,7 @@ export const useChatStore = create<ChatState>()((setState, getState) => ({
   finaliseStreamingMessage: async () => {
     const session = getState().activeSession
     if (!session) return
+    console.log('[chatStore] finaliseStreamingMessage: session', session.id, '| total messages', session.messages.length)
     const messages = session.messages.map((m) =>
       m.streaming ? { ...m, streaming: false } : m,
     )
@@ -122,6 +128,7 @@ export const useChatStore = create<ChatState>()((setState, getState) => ({
   },
 
   archiveSession: async (id) => {
+    console.log('[chatStore] archiveSession: id', id)
     const session = await get<ChatSession>(`chat:session:${id}`)
     if (session) {
       session.status = 'archived'
@@ -138,6 +145,7 @@ export const useChatStore = create<ChatState>()((setState, getState) => ({
   },
 
   deleteSession: async (id) => {
+    console.log('[chatStore] deleteSession: id', id)
     await del(`chat:session:${id}`)
     const sessions = getState().sessions.filter((s) => s.id !== id)
     setState({ sessions })

--- a/src/stores/journalStore.ts
+++ b/src/stores/journalStore.ts
@@ -42,6 +42,7 @@ export const useJournalStore = create<JournalState>()((setState, getState) => ({
   },
 
   addEntry: async (entry) => {
+    console.log('[journalStore] addEntry: id', entry.id, '| content', entry.content.length, 'chars')
     const entries = [entry, ...getState().entries]
     setState({ entries })
     await set('nopy-entries', entries)
@@ -49,6 +50,7 @@ export const useJournalStore = create<JournalState>()((setState, getState) => ({
   },
 
   updateEntry: async (id, updates) => {
+    console.log('[journalStore] updateEntry: id', id, '| updating keys', Object.keys(updates).join(', '))
     const entries = getState().entries.map((e) =>
       e.id === id ? { ...e, ...updates, updatedAt: new Date().toISOString() } : e
     )
@@ -59,6 +61,7 @@ export const useJournalStore = create<JournalState>()((setState, getState) => ({
   },
 
   deleteEntry: async (id) => {
+    console.log('[journalStore] deleteEntry: id', id)
     const entry = getState().entries.find((e) => e.id === id)
     const entries = getState().entries.filter((e) => e.id !== id)
     setState({ entries })

--- a/src/stores/profileStore.ts
+++ b/src/stores/profileStore.ts
@@ -32,6 +32,7 @@ export const useProfileStore = create<ProfileState>()((setState, getState) => ({
 
   loadProfile: async () => {
     const profile = await get<PsychologicalProfile>('nopy-profile')
+    console.log('[profileStore] loadProfile: profile found', profile != null, profile ? '| entriesAnalysed ' + profile.entriesAnalysed : '')
     setState({ profile: profile ?? null, loaded: true })
   },
 
@@ -45,9 +46,11 @@ export const useProfileStore = create<ProfileState>()((setState, getState) => ({
     const setPhase = (phase: string) => setState({ phase })
     const setProgress = (current: number, total: number, title: string) => setState({ progress: { current, total, title } })
     setState({ generating: true, phase: '', progress: { current: 0, total: 0, title: '' } })
+    console.log('[profileStore] generateProfile: starting | total entries', entries.length)
     try {
     // Step 1: Process unindexed entries via Haiku
     const unindexed = entries.filter((e) => !e.indexed)
+    console.log('[profileStore] Step 1/5: unindexed entries to process', unindexed.length)
     if (unindexed.length > 0) {
       setPhase(`Step 1/5 — Indexing ${unindexed.length} unprocessed entries...`)
       const results = await processAllEntries(entries, apiKey, false, setProgress, signal)
@@ -67,40 +70,51 @@ export const useProfileStore = create<ProfileState>()((setState, getState) => ({
           const entry = updated.find((e) => e.id === id)
           if (entry) await saveEntryToDisk(entry, journalPath)
         }
+        console.log('[profileStore] Step 1/5: processed', results.size, 'entries')
         entries = updated
       }
     } else {
+      console.log('[profileStore] Step 1/5: all entries already indexed')
       setPhase('Step 1/5 — All entries already indexed')
     }
 
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
 
     // Step 2: Compute local stats
+    console.log('[profileStore] Step 2/5: computing local stats on', entries.length, 'entries')
     setPhase('Step 2/5 — Computing metrics...')
     setProgress(0, 0, '')
     const localStats = computeLocalStats(entries)
 
+    console.log('[profileStore] Step 2/5: localStats — averageMood', localStats.averageMood, '| streak', localStats.journalingStreak, '| avgEntryLength', localStats.avgEntryLength, '| reflectionDepth', localStats.reflectionDepth)
+
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
 
     // Step 3: Generate summary profile via Haiku
+    console.log('[profileStore] Step 3/5: generating summary profile via Haiku')
     setPhase('Step 3/5 — Generating summary profile (Haiku)...')
     const narrative = await generateProfileFromEntries(entries, apiKey, signal)
+
+    console.log('[profileStore] Step 3/5: summary profile generated')
 
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
 
     // Step 4: Generate full psychological profile via Opus
+    console.log('[profileStore] Step 4/5: generating full profile via Opus')
     setPhase('Step 4/5 — Writing full psychological profile (Opus 4.6)...')
     let fullProfile: string | null = null
     try {
       fullProfile = await generateFullProfile(entries, apiKey, signal)
+      console.log('[profileStore] Step 4/5: full profile generated', fullProfile?.length ?? 0, 'chars')
     } catch (e) {
-      console.error('[profile] Full profile generation failed:', e)
+      console.error('[profileStore] Step 4/5: full profile generation failed —', e)
       setPhase('Step 4/5 — Full profile generation failed, continuing...')
     }
 
     if (signal?.aborted) throw new DOMException('Aborted', 'AbortError')
 
     // Step 5: Save everything
+    console.log('[profileStore] Step 5/5: saving profile')
     setPhase('Step 5/5 — Saving profile...')
     const profile: PsychologicalProfile = {
       ...narrative,
@@ -112,12 +126,14 @@ export const useProfileStore = create<ProfileState>()((setState, getState) => ({
 
     const { setProfile } = getState()
     await setProfile(profile)
+    console.log('[profileStore] generateProfile: complete | entriesAnalysed', profile.entriesAnalysed, '| themes', profile.themes.length, '| cognitivePatterns', profile.cognitivePatterns.length)
     setPhase('Profile generated successfully')
     } catch (e) {
       if (e instanceof DOMException && e.name === 'AbortError') {
+        console.log('[profileStore] generateProfile: aborted by user')
         setState({ phase: 'Cancelled' })
       } else {
-        console.error('Profile generation failed:', e)
+        console.error('[profileStore] generateProfile: failed —', e)
         setState({ phase: 'Generation failed — check console for details' })
       }
     } finally {


### PR DESCRIPTION
…ta leaks

Remove logs that exposed personal content from the browser console:
- contextAssembler: remove profile theme names, entry title, session summary content preview (100 chars), and message content previews
- SettingsView: remove filesystem path from two log statements

Add structured, privacy-safe logging to all data parsing and transformation functions:
- anthropic: log client reuse/creation, model/message/token params, response lengths, stream completion, and error messages
- entryProcessor: log input char counts, response lengths, parse outcomes (mood value, tag count, summary length), per-entry failures, pipeline entry counts, and computeLocalStats results
- fs: log frontmatter detection, key count, JSON parse failure count per file, and per-file import type (nopy vs plain)
- chatStore: log session lifecycle (create, load, add message, finalise, archive, delete) using only IDs, counts, and booleans
- journalStore: log addEntry, updateEntry (keys changed), deleteEntry
- profileStore: log all 5 generation steps with counts and stats

All logs are restricted to: counts, char/token lengths, UUIDs, booleans, model names, and enum values — never journal content, titles, summaries, themes, file paths, or API keys.